### PR TITLE
Simplifying markup, css and design

### DIFF
--- a/app/styles/_projects.less
+++ b/app/styles/_projects.less
@@ -2,120 +2,124 @@
 // Projects page
 // -------------
 
+// added here as this rule only applies to the project list page
+// as no other pages utilize the alerts class
+.col-md-12 > .alerts:first-child {
+  margin-top: 20px;
+}
+
 .project-actions {
-  margin: 16px 0 0;
+  margin: 20px 0 0;
   @media (min-width: @screen-md-min) {
     margin-top: 0;
   }
   .project-action-item {
-    margin-left: 10px;
+    margin-left: 12px;
   }
 }
 
 .project-additional-info.list-view-pf-additional-info {
-  .align-items(@align: flex-start);
-  @media (min-width: @screen-xs-min) {
-    .align-items(@align: center);
-  }
-}
-
-.project-age {
-  .align-items(@align: flex-start);
-  .flex(@columns: 1 1 auto);
-  .flex-display(@display: flex);
-  @media (min-width: @screen-xs-min) {
-    .align-items(@align: center);
-    width: 45%;
-  }
-  .h1 {
-    margin: 0;
-    text-align: center;
-  }
-  .h2 {
-    margin-bottom: 0;
-    margin-top: 10px;
-  }
-  .h3 {
-    text-align: left;
-    font-size: 14px;
-    margin-top: 8px;
-    margin-bottom: 0;
-  }
-}
-
-.project-background {
-  background-color: #fff;
-  h1 {
-    display: inline-block;
-    margin-bottom: 0;
-    margin-top: 0;
-  }
-}
-
-.project-bar {
-  .form-control {
-    .flex(@columns: 1);
-    padding-left: 8px;
-    @media (min-width: @screen-sm-min) {
-      .flex(@columns: 0);
-      min-width: 200px;
-    }
-  }
-  .project-sort .form-group {
-    margin: 0;
-  }
-  .vertical-divider {
-    border-left: 1px solid #bbb;
-    display: inline-block;
-    height: 25px;
-    margin: 0 7px;
-    vertical-align: middle;
-    width: 1px;
-  }
-}
-
-.projects-content {
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.project-description.list-group-item-text {
-  .flex(@columns: 1 1 auto);
-  margin-bottom: 0px;
-  width: 100%; // IE 10
-  @media (min-width: @screen-xs-min) {
-    margin-bottom: 0;
-    width: 55%;
+  @media (min-width: @screen-md-min) {
+    width: 60%;
   }
 }
 
 .project-info.list-group-item {
   border-bottom: 0;
+  border-color: #e0e0e0;
   padding: 10px 20px;
 }
 
 .project-name-item.list-group-item-heading {
   @media (min-width: @screen-md-min) {
     white-space: normal;
+    width: 40%;
+  }
+  .h1 {
+    margin-bottom: 0;
+    margin-top: 0;
+    [data-toggle='tooltip'] {
+      cursor: help;
+      margin-left: 5px;
+    }
+    a {
+      line-height: initial;
+    }
+  }
+  p {
+    margin-bottom: 0;
+    margin-top: 5px;
   }
 }
 
-.project-names.list-view-pf-description {
-  .flex(@columns: 1 1 auto);
-  width: 100%; // IE 10
-  @media (min-width: @screen-md-min) {
-    width: 50%;
+.projects-bar {
+  display: flex;
+  flex-direction: column;
+  @media (min-width: 650px) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  h1 {
+    margin-bottom: 0 !important;
+    margin-top: 0 !important;
+  }
+  .projects-add {
+    display: flex;
+    justify-content: flex-end;
+    margin: -27px 0 20px 0;
+    @media (min-width: 650px) {
+      margin-left: 40px;
+      margin-top: 0;
+      order: 2;
+    }
+  }
+  .projects-options {
+    display: flex;
+    flex-direction: column;
+    @media (min-width: 650px) {
+      flex-direction: row;
+    }
+  }
+  .projects-search {
+    display: flex;
+    margin-bottom: 20px;
+    .search-pf {
+      display: block;
+      flex: 0 1 auto;
+      &.has-button .form-group {
+        display: block;
+      }
+    }
+  }
+  .projects-sort {
+    flex: 1 0 auto;
+    .form-group {
+      margin: 0;
+    }
+  }
+  .vertical-divider {
+    border-left: 1px solid #bbb;
+    display: inline-block;
+    height: 27px;
+    margin: 0 7px;
+    vertical-align: middle;
+    width: 1px;
   }
 }
 
-.project-summary .h1 {
-  margin-top: 0;
+.projects-header {
+  margin-top: 21px;
+}
+
+.projects-instructions-link {
+  white-space: pre;
 }
 
 .projects-list {
   border-top: 0;
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.15), 0 2px 2px 0 rgba(0, 0, 0, 0.1), 0 1px 5px 0 rgba(0, 0, 0, 0.09);
   margin-bottom: 20px;
   .project-info:hover {
-    background-color: #bee1f4;
+    background-color: @table-bg-hover;
   }
 }

--- a/app/views/projects.html
+++ b/app/views/projects.html
@@ -8,152 +8,137 @@
     <div class="middle-section">
       <div class="middle-container">
         <div class="middle-content">
-          <div ng-if="!showGetStarted" class="container-fluid surface-shaded projects-content mar-left-none mar-right-none"> <!-- Safari needs surface-shaded at mobile -->
-            <div ng-if="(projects | hashSize) === 0" class="text-muted">Loading...</div>
-            <div ng-if="(projects | hashSize) !== 0" class="gutter-top pad-top-none">
-              <div class="project-background mar-bottom-xl">
-                <div class="pad-top-xl pad-left-xl pad-right-xl">
-                  <div>
-                    <div>
-                      <h1>Projects</h1>
-                      <a ng-if="canCreate" href="create-project" class="btn btn-md btn-primary pull-right">
-                        <span>New project</span>
-                      </a>
-                    </div>
-                  </div>
+          <div class="container surface-shaded"> <!-- Safari needs surface-shaded at mobile -->
+            <div class="row">
+              <div class="col-md-12">
+                <div ng-if="alerts" class="alerts">
+                  <alerts alerts="alerts"></alerts>
                 </div>
 
-                <div row cross-axis="center" class="project-bar pad-top-lg pad-right-xl pad-bottom-lg pad-left-xl table-toolbar form-inline">
-                  <form role="form" class="search-pf has-button">
-                    <div class="form-group has-clear">
-                      <div class="search-pf-input-group">
-                        <label for="search1" class="sr-only">Search</label>
-                        <input
-                          type="search"
-                          class="form-control"
-                          placeholder="Search"
-                          ng-init="search.text = ''"
-                          ng-model="search.text">
-                        <button
-                          type="button"
-                          class="clear"
-                          aria-hidden="true"
-                          ng-if="search.text"
-                          ng-click="search.text = ''">
-                            <span class="pficon pficon-close"></span>
-                        </button>
-                      </div>
-                    </div>
-                  </form>
-
-                  <span class="mar-left-sm mar-right-sm">
-                    <span class="hidden-xs vertical-divider"></span>
-                  </span>
-
-                  <div class="project-sort">
-                    <div pf-sort config="sortConfig" class="sort-controls"></div>
+                <div ng-if="!showGetStarted">
+                  <div ng-if="(projects | hashSize) === 0" class="empty-state-message">
+                    <h2 class="text-center" id="temporary-loading-message">Loading...</h2>
                   </div>
-
-                  <span class="hidden-xs mar-left-sm mar-right-sm">
-                    <span class="vertical-divider"></span>
-                  </span>
-                </div>
-              </div>
-              <div ng-if="alerts" class="mar-left-xl mar-right-xl">
-                <alerts alerts="alerts"></alerts>
-              </div>
-
-              <div
-                class="empty-state-message text-center"
-                ng-if="(projects | findProject:search.text).length === 0">
-                  <h2>{{emptyMessage}}</h2>
-              </div>
-
-              <div class="list-group list-view-pf projects-list tile-click">
-                <div ng-repeat="project in projects | findProject:search.text"
-                     class="list-group-item project-info mar-left-xl mar-right-xl">
-                  <div row class="list-view-pf-actions project-actions"
-                       ng-if="project.status.phase == 'Active'">
-                   <span class="fa-lg project-action-item">
-                     <a ng-href="project/{{project.metadata.name}}/edit" class="action-button">
-                       <i class="fa fa-pencil" aria-hidden="true"></i>
-                       <span class="sr-only">Edit Project</span>
-                     </a>
-                   </span>
-                   <span>
-                     <delete-link
-                       class="fa-lg project-action-item"
-                       kind="Project"
-                       resource-name="{{project.metadata.name}}"
-                       project-name="{{project.metadata.name}}"
-                       display-name="{{(project | displayName)}}"
-                       type-name-to-confirm="true"
-                       stay-on-current-page="true"
-                       alerts="alerts"
-                       button-only>
-                     </delete-link>
-                   </span>
-                  </div>
-
-                  <div class="list-view-pf-main-info">
-                    <div class="list-view-pf-description project-names">
-                      <div class="list-group-item-heading project-name-item">
-                        <div class="project-summary">
-                          <div class="h1">
-                            <a class="tile-target" href="project/{{project.metadata.name}}">{{project.metadata.annotations["openshift.io/display-name"] || project.metadata.name}}</a> <!-- {{(project | uniqueDisplayName : projects)}} -->
-                            <span ng-if="project.status.phase != 'Active'"
-                                  data-toggle="tooltip"
-                                  title="This project has been marked for deletion."
-                                  class="pficon pficon-warning-triangle-o"
-                                  style="cursor: help; vertical-align: top; margin-left: 5px;"></span>
+                  <div ng-if="(projects | hashSize) !== 0">
+                    <div class="projects-header">
+                      <div class="projects-bar">
+                        <h1>Projects</h1>
+                        <div class="projects-options">
+                          <div class="projects-add" ng-if="canCreate">
+                            <a href="create-project" class="btn btn-md btn-primary">
+                              <span>New project</span>
+                            </a>
+                          </div>
+                          <div class="projects-search">
+                            <form role="form" class="search-pf has-button">
+                              <div class="form-group has-clear">
+                                <div class="search-pf-input-group">
+                                  <label for="search-projects" class="sr-only">Search</label>
+                                  <input
+                                    type="search"
+                                    class="form-control"
+                                    placeholder="Search"
+                                    id="search-projects"
+                                    ng-init="search.text = ''"
+                                    ng-model="search.text">
+                                  <button
+                                    type="button"
+                                    class="clear"
+                                    aria-hidden="true"
+                                    ng-if="search.text"
+                                    ng-click="search.text = ''">
+                                    <span class="pficon pficon-close"></span>
+                                  </button>
+                                </div>
+                              </div>
+                            </form>
+                            <span class="vertical-divider"></span>
+                            <div class="projects-sort">
+                              <div pf-sort config="sortConfig" class="sort-controls"></div>
+                            </div>
                           </div>
                         </div>
-                        <div class="hidden-xs project-name-item">
-                          <p>{{project.metadata.name}}</p>
-                        </div>
-                      </div>
-
-                      <div flex row mobile="column" class="list-view-pf-additional-info project-additional-info">
-                        <span flex class="list-group-item-text project-description">
-                          <truncate-long-text content="project | description" limit="265" use-word-boundary="true"></truncate-long-text>
-                        </span>
                       </div>
                     </div>
+                    <div ng-if="(projects | findProject:search.text).length === 0" class="text-center">
+                      <h2>{{emptyMessage}}</h2>
+                    </div>
+                    <div class="list-group list-view-pf projects-list">
+                      <div ng-repeat="project in projects | findProject:search.text" class="list-group-item project-info tile-click">
+                        <div row class="list-view-pf-actions project-actions" ng-if="project.status.phase == 'Active'">
+                          <span class="fa-lg project-action-item">
+                            <a ng-href="project/{{project.metadata.name}}/edit" class="action-button">
+                              <i class="fa fa-pencil" aria-hidden="true"></i>
+                              <span class="sr-only">Edit Project</span>
+                            </a>
+                          </span>
+                          <span>
+                            <delete-link
+                              class="fa-lg project-action-item"
+                              kind="Project"
+                              resource-name="{{project.metadata.name}}"
+                              project-name="{{project.metadata.name}}"
+                              display-name="{{(project | displayName)}}"
+                              type-name-to-confirm="true"
+                              stay-on-current-page="true"
+                              alerts="alerts"
+                              button-only>
+                            </delete-link>
+                          </span>
+                        </div>
+                        <div class="list-view-pf-main-info">
+                          <div class="list-view-pf-description project-names">
+                            <div class="list-group-item-heading project-name-item">
+                              <h2 class="h1">
+                                <a class="tile-target" href="project/{{project.metadata.name}}">{{project.metadata.annotations["openshift.io/display-name"] || project.metadata.name}}</a> <!-- {{(project | uniqueDisplayName : projects)}} -->
+                                <span ng-if="project.status.phase != 'Active'"
+                                  data-toggle="tooltip"
+                                  title="This project has been marked for deletion."
+                                  class="pficon pficon-warning-triangle-o"></span>
+                              </h2>
+                              <p class="hidden-xs project-name-item" ng-if="project.metadata.annotations['openshift.io/display-name']">{{project.metadata.name}}</p>
+                            </div>
+                            <div class="list-view-pf-additional-info project-additional-info">
+                              <span class="list-group-item-text project-description">
+                                <truncate-long-text content="project | description" limit="265" use-word-boundary="true"></truncate-long-text>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <p class="projects-instructions" ng-if="canCreate === false">
+                      <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command
+                        <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
+                      <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" class="projects-instructions-link"></span>
+                    </p>
+                    <p class="projects-instructions" ng-if="(projects | findProject:$search.text).length !== 0">
+                      A project admin can add you to a role on a project by running the command
+                      <code>oc policy add-role-to-user &lt;role&gt; {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>
+                    </p>
                   </div>
                 </div>
-              </div>
-              <div ng-if="canCreate === false" class="mar-top-md mar-left-xl mar-right-xl">
-                <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command
-                  <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
-                <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" style="white-space:pre;"></span>
-              </div>
-              <div class="mar-top-md mar-left-xl mar-right-xl"
-                   ng-if="(projects | findProject:$search.text).length !== 0">
-                A project admin can add you to a role on a project by running the command
-                <code>oc policy add-role-to-user &lt;role&gt; {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>
-              </div>
-            </div>
-          </div>
 
-          <div ng-if="showGetStarted">
-            <div class="container gutter-top" ng-if="(alerts | hashSize) > 0">
-              <alerts alerts="alerts"></alerts>
-            </div>
-            <div class="empty-state-message empty-state-full-page text-center">
-              <h1>Welcome to OpenShift.</h1>
-              <p>
-                OpenShift helps you quickly develop, host, and scale applications.<br>
-                <span ng-if="canCreate">Create a project for your application.</span>
-              </p>
-              <a ng-if="canCreate" href="create-project" class="btn btn-lg btn-primary">New Project</a>
-              <p>To learn more, visit the OpenShift <a target="_blank" ng-href="{{'' | helpLink}}">documentation</a>.</p>
-              <p ng-if="canCreate === false">
-                <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command<br>
-                  <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
-                <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" style="white-space:pre;"></span>
-              </p>
-            </div>
-          </div>
+                <div ng-if="showGetStarted">
+                  <div class="empty-state-message empty-state-full-page text-center">
+                    <h1>Welcome to OpenShift.</h1>
+                    <p>
+                      OpenShift helps you quickly develop, host, and scale applications.<br>
+                      <span ng-if="canCreate">Create a project for your application.</span>
+                    </p>
+                    <a ng-if="canCreate" href="create-project" class="btn btn-lg btn-primary">New Project</a>
+                    <p>To learn more, visit the OpenShift <a target="_blank" ng-href="{{'' | helpLink}}">documentation</a>.</p>
+                    <p class="projects-instructions" ng-if="canCreate === false">
+                      <span ng-if="!newProjectMessage">A cluster admin can create a project for you by running the command<br>
+                        <code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>
+                        <span ng-if="newProjectMessage" ng-bind-html="newProjectMessage | linky" class="projects-instructions-link"></span>
+                    </p>
+                  </div>
+                </div>
+
+              </div><!-- /col -->
+            </div><!-- /row -->
+          </div><!-- /container -->
         </div><!-- /middle-content -->
       </div><!-- /middle-container -->
     </div><!-- /middle-section -->

--- a/dist/scripts/templates.js
+++ b/dist/scripts/templates.js
@@ -8717,51 +8717,51 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"middle-section\">\n" +
     "<div class=\"middle-container\">\n" +
     "<div class=\"middle-content\">\n" +
-    "<div ng-if=\"!showGetStarted\" class=\"container-fluid surface-shaded projects-content mar-left-none mar-right-none\"> \n" +
-    "<div ng-if=\"(projects | hashSize) === 0\" class=\"text-muted\">Loading...</div>\n" +
-    "<div ng-if=\"(projects | hashSize) !== 0\" class=\"gutter-top pad-top-none\">\n" +
-    "<div class=\"project-background mar-bottom-xl\">\n" +
-    "<div class=\"pad-top-xl pad-left-xl pad-right-xl\">\n" +
-    "<div>\n" +
-    "<div>\n" +
+    "<div class=\"container surface-shaded\"> \n" +
+    "<div class=\"row\">\n" +
+    "<div class=\"col-md-12\">\n" +
+    "<div ng-if=\"alerts\" class=\"alerts\">\n" +
+    "<alerts alerts=\"alerts\"></alerts>\n" +
+    "</div>\n" +
+    "<div ng-if=\"!showGetStarted\">\n" +
+    "<div ng-if=\"(projects | hashSize) === 0\" class=\"empty-state-message\">\n" +
+    "<h2 class=\"text-center\" id=\"temporary-loading-message\">Loading...</h2>\n" +
+    "</div>\n" +
+    "<div ng-if=\"(projects | hashSize) !== 0\">\n" +
+    "<div class=\"projects-header\">\n" +
+    "<div class=\"projects-bar\">\n" +
     "<h1>Projects</h1>\n" +
-    "<a ng-if=\"canCreate\" href=\"create-project\" class=\"btn btn-md btn-primary pull-right\">\n" +
+    "<div class=\"projects-options\">\n" +
+    "<div class=\"projects-add\" ng-if=\"canCreate\">\n" +
+    "<a href=\"create-project\" class=\"btn btn-md btn-primary\">\n" +
     "<span>New project</span>\n" +
     "</a>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "<div row cross-axis=\"center\" class=\"project-bar pad-top-lg pad-right-xl pad-bottom-lg pad-left-xl table-toolbar form-inline\">\n" +
+    "<div class=\"projects-search\">\n" +
     "<form role=\"form\" class=\"search-pf has-button\">\n" +
     "<div class=\"form-group has-clear\">\n" +
     "<div class=\"search-pf-input-group\">\n" +
-    "<label for=\"search1\" class=\"sr-only\">Search</label>\n" +
-    "<input type=\"search\" class=\"form-control\" placeholder=\"Search\" ng-init=\"search.text = ''\" ng-model=\"search.text\">\n" +
+    "<label for=\"search-projects\" class=\"sr-only\">Search</label>\n" +
+    "<input type=\"search\" class=\"form-control\" placeholder=\"Search\" id=\"search-projects\" ng-init=\"search.text = ''\" ng-model=\"search.text\">\n" +
     "<button type=\"button\" class=\"clear\" aria-hidden=\"true\" ng-if=\"search.text\" ng-click=\"search.text = ''\">\n" +
     "<span class=\"pficon pficon-close\"></span>\n" +
     "</button>\n" +
     "</div>\n" +
     "</div>\n" +
     "</form>\n" +
-    "<span class=\"mar-left-sm mar-right-sm\">\n" +
-    "<span class=\"hidden-xs vertical-divider\"></span>\n" +
-    "</span>\n" +
-    "<div class=\"project-sort\">\n" +
+    "<span class=\"vertical-divider\"></span>\n" +
+    "<div class=\"projects-sort\">\n" +
     "<div pf-sort config=\"sortConfig\" class=\"sort-controls\"></div>\n" +
     "</div>\n" +
-    "<span class=\"hidden-xs mar-left-sm mar-right-sm\">\n" +
-    "<span class=\"vertical-divider\"></span>\n" +
-    "</span>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"alerts\" class=\"mar-left-xl mar-right-xl\">\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
     "</div>\n" +
-    "<div class=\"empty-state-message text-center\" ng-if=\"(projects | findProject:search.text).length === 0\">\n" +
+    "</div>\n" +
+    "<div ng-if=\"(projects | findProject:search.text).length === 0\" class=\"text-center\">\n" +
     "<h2>{{emptyMessage}}</h2>\n" +
     "</div>\n" +
-    "<div class=\"list-group list-view-pf projects-list tile-click\">\n" +
-    "<div ng-repeat=\"project in projects | findProject:search.text\" class=\"list-group-item project-info mar-left-xl mar-right-xl\">\n" +
+    "<div class=\"list-group list-view-pf projects-list\">\n" +
+    "<div ng-repeat=\"project in projects | findProject:search.text\" class=\"list-group-item project-info tile-click\">\n" +
     "<div row class=\"list-view-pf-actions project-actions\" ng-if=\"project.status.phase == 'Active'\">\n" +
     "<span class=\"fa-lg project-action-item\">\n" +
     "<a ng-href=\"project/{{project.metadata.name}}/edit\" class=\"action-button\">\n" +
@@ -8777,18 +8777,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "<div class=\"list-view-pf-main-info\">\n" +
     "<div class=\"list-view-pf-description project-names\">\n" +
     "<div class=\"list-group-item-heading project-name-item\">\n" +
-    "<div class=\"project-summary\">\n" +
-    "<div class=\"h1\">\n" +
+    "<h2 class=\"h1\">\n" +
     "<a class=\"tile-target\" href=\"project/{{project.metadata.name}}\">{{project.metadata.annotations[\"openshift.io/display-name\"] || project.metadata.name}}</a> \n" +
-    "<span ng-if=\"project.status.phase != 'Active'\" data-toggle=\"tooltip\" title=\"This project has been marked for deletion.\" class=\"pficon pficon-warning-triangle-o\" style=\"cursor: help; vertical-align: top; margin-left: 5px\"></span>\n" +
+    "<span ng-if=\"project.status.phase != 'Active'\" data-toggle=\"tooltip\" title=\"This project has been marked for deletion.\" class=\"pficon pficon-warning-triangle-o\"></span>\n" +
+    "</h2>\n" +
+    "<p class=\"hidden-xs project-name-item\" ng-if=\"project.metadata.annotations['openshift.io/display-name']\">{{project.metadata.name}}</p>\n" +
     "</div>\n" +
-    "</div>\n" +
-    "<div class=\"hidden-xs project-name-item\">\n" +
-    "<p>{{project.metadata.name}}</p>\n" +
-    "</div>\n" +
-    "</div>\n" +
-    "<div flex row mobile=\"column\" class=\"list-view-pf-additional-info project-additional-info\">\n" +
-    "<span flex class=\"list-group-item-text project-description\">\n" +
+    "<div class=\"list-view-pf-additional-info project-additional-info\">\n" +
+    "<span class=\"list-group-item-text project-description\">\n" +
     "<truncate-long-text content=\"project | description\" limit=\"265\" use-word-boundary=\"true\"></truncate-long-text>\n" +
     "</span>\n" +
     "</div>\n" +
@@ -8796,21 +8792,18 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +
-    "<div ng-if=\"canCreate === false\" class=\"mar-top-md mar-left-xl mar-right-xl\">\n" +
+    "<p class=\"projects-instructions\" ng-if=\"canCreate === false\">\n" +
     "<span ng-if=\"!newProjectMessage\">A cluster admin can create a project for you by running the command\n" +
     "<code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>\n" +
-    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky\" style=\"white-space:pre\"></span>\n" +
-    "</div>\n" +
-    "<div class=\"mar-top-md mar-left-xl mar-right-xl\" ng-if=\"(projects | findProject:$search.text).length !== 0\">\n" +
+    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky\" class=\"projects-instructions-link\"></span>\n" +
+    "</p>\n" +
+    "<p class=\"projects-instructions\" ng-if=\"(projects | findProject:$search.text).length !== 0\">\n" +
     "A project admin can add you to a role on a project by running the command\n" +
     "<code>oc policy add-role-to-user &lt;role&gt; {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>\n" +
-    "</div>\n" +
+    "</p>\n" +
     "</div>\n" +
     "</div>\n" +
     "<div ng-if=\"showGetStarted\">\n" +
-    "<div class=\"container gutter-top\" ng-if=\"(alerts | hashSize) > 0\">\n" +
-    "<alerts alerts=\"alerts\"></alerts>\n" +
-    "</div>\n" +
     "<div class=\"empty-state-message empty-state-full-page text-center\">\n" +
     "<h1>Welcome to OpenShift.</h1>\n" +
     "<p>\n" +
@@ -8819,11 +8812,14 @@ angular.module('openshiftConsoleTemplates', []).run(['$templateCache', function(
     "</p>\n" +
     "<a ng-if=\"canCreate\" href=\"create-project\" class=\"btn btn-lg btn-primary\">New Project</a>\n" +
     "<p>To learn more, visit the OpenShift <a target=\"_blank\" ng-href=\"{{'' | helpLink}}\">documentation</a>.</p>\n" +
-    "<p ng-if=\"canCreate === false\">\n" +
+    "<p class=\"projects-instructions\" ng-if=\"canCreate === false\">\n" +
     "<span ng-if=\"!newProjectMessage\">A cluster admin can create a project for you by running the command<br>\n" +
     "<code>oadm new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code></span>\n" +
-    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky\" style=\"white-space:pre\"></span>\n" +
+    "<span ng-if=\"newProjectMessage\" ng-bind-html=\"newProjectMessage | linky\" class=\"projects-instructions-link\"></span>\n" +
     "</p>\n" +
+    "</div>\n" +
+    "</div>\n" +
+    "</div>\n" +
     "</div>\n" +
     "</div>\n" +
     "</div>\n" +

--- a/dist/styles/main.css
+++ b/dist/styles/main.css
@@ -3282,8 +3282,8 @@ to{transform:rotate(359deg)}
 .key-value-editor.as-sortable-dragging .as-sortable-item-delete,.key-value-editor.as-sortable-dragging .input-group-addon,.key-value-editor.as-sortable-dragging input{opacity:.65}
 .key-value-editor .as-sortable-DISABLED-item-delete:hover,.key-value-editor .as-sortable-item-delete:hover,.key-value-editor .as-sortable-item-handle:hover,.key-value-editor.as-sortable-dragging .as-sortable-item-handle{opacity:1}
 .key-value-editor .as-sortable-DISABLED-item-delete,.key-value-editor .as-sortable-item-delete,.key-value-editor .as-sortable-item-handle{display:inline-block;font-size:15px;opacity:.65;padding:6px;vertical-align:middle}
-.key-value-editor .as-sortable-item-delete{color:#333}
-.key-value-editor .as-sortable-item-delete:active,.key-value-editor .as-sortable-item-delete:focus,.key-value-editor .as-sortable-item-delete:hover{text-decoration:none}
+.key-value-editor .as-sortable-DISABLED-item-delete,.key-value-editor .as-sortable-item-delete{color:#333}
+.key-value-editor .as-sortable-DISABLED-item-delete:active,.key-value-editor .as-sortable-DISABLED-item-delete:focus,.key-value-editor .as-sortable-DISABLED-item-delete:hover,.key-value-editor .as-sortable-item-delete:active,.key-value-editor .as-sortable-item-delete:focus,.key-value-editor .as-sortable-item-delete:hover{text-decoration:none}
 .key-value-editor .as-sortable-item-handle{cursor:move}
 .key-value-editor .as-sortable-placeholder{border-top:2px solid #0088ce;clear:left;width:100%!important}
 .log-view,.sidebar-left .navbar-sidebar .sidebar-header:after,ul.messenger.messenger-theme-flat .messenger-message:after{clear:both}
@@ -4457,6 +4457,7 @@ td.visible-print,th.visible-print{display:table-cell!important}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a span{display:block;margin:0}
 .nav-sidenav-secondary .dropdown-header,.sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li .hover-nav ul.nav-sidenav-secondary li a{padding-left:15px}
 }
+.projects-list,.tile{box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09)}
 @media (min-width:1200px){.sidebar-left .navbar-sidebar,.sidebar-left .navbar-sidebar .nav-sidenav-secondary.hover-nav.dropdown-menu{font-size:14px}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a{padding-bottom:25px;padding-top:25px}
 .sidebar-left .navbar-sidebar ul.nav-sidenav-primary>li>a .fa-angle-right{font-size:18px}
@@ -4596,7 +4597,7 @@ body,html{margin:0;padding:0}
 .events-table td{overflow-wrap:break-word}
 .events-table .pficon{vertical-align:middle}
 .events-table .severity-icon-td{padding-left:0;padding-right:0}
-.tile{background:#fff;box-shadow:0 3px 1px -2px rgba(0,0,0,.15),0 2px 2px 0 rgba(0,0,0,.1),0 1px 5px 0 rgba(0,0,0,.09);padding:10px 20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
+.tile{background:#fff;padding:10px 20px;margin-bottom:20px;word-wrap:break-word;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow-x:hidden}
 .tile h1,.tile h2,.tile h3{margin:10.5px 0px}
 .tile h3 .tile-timestamp{color:#9c9c9c;font-size:84%}
 @media (max-width:768px){.tile h3 .tile-timestamp:before{content:'\2014\00a0'}
@@ -4769,8 +4770,7 @@ kubernetes-topology-graph{height:700px}
 .log-line-number{-moz-user-select:none;-webkit-user-select:none;-ms-user-select:none;border-right:1px #272b30 solid;padding-right:10px;vertical-align:top;white-space:nowrap;width:60px;color:#72767b}
 .log-line-text{padding:0 10px;white-space:pre-wrap;width:100%;overflow-wrap:break-word}
 .log-line-text::-moz-selection{color:#101214;background:#e5e5e5}
-.project-background,.table-log-pods{background-color:#fff}
-.table-log-pods{border:1px solid #D1D1D1}
+.table-log-pods{background-color:#fff;border:1px solid #D1D1D1}
 .table-log-pods>tbody+tbody{border-top-width:1px}
 .log-fixed-height.empty-state-message{margin-top:0}
 .chromeless .log-loading-msg{font-family:inherit;line-height:1.1;color:inherit;font-size:19px;font-weight:300;margin:60px auto;max-width:600px;padding:0 20px;text-align:center}
@@ -4789,37 +4789,37 @@ kubernetes-topology-graph{height:700px}
 .settings-item{margin:4px 8px 4px 0}
 .hide-if-empty:empty{display:none!important}
 .donut-title-med-pf{font-size:22.5px;font-weight:300}
-.project-actions{margin:16px 0 0}
+.col-md-12>.alerts:first-child{margin-top:20px}
+.project-actions{margin:20px 0 0}
+.project-actions .project-action-item{margin-left:12px}
+.project-info.list-group-item{border-bottom:0;border-color:#e0e0e0;padding:10px 20px}
 @media (min-width:992px){.project-actions{margin-top:0}
-.project-name-item.list-group-item-heading{white-space:normal}
+.project-additional-info.list-view-pf-additional-info{width:60%}
+.project-name-item.list-group-item-heading{white-space:normal;width:40%}
 }
-.project-actions .project-action-item{margin-left:10px}
-.project-additional-info.list-view-pf-additional-info{-webkit-align-items:flex-start;-moz-align-items:flex-start;align-items:flex-start}
-@media (min-width:480px){.project-additional-info.list-view-pf-additional-info{-webkit-align-items:center;-moz-align-items:center;align-items:center}
+.project-name-item.list-group-item-heading .h1{margin-bottom:0;margin-top:0}
+.project-name-item.list-group-item-heading .h1 [data-toggle=tooltip]{cursor:help;margin-left:5px}
+.project-name-item.list-group-item-heading .h1 a{line-height:initial}
+.project-name-item.list-group-item-heading p{margin-bottom:0;margin-top:5px}
+.projects-bar{display:flex;flex-direction:column}
+@media (min-width:650px){.projects-bar{flex-direction:row;justify-content:space-between}
 }
-.project-age{-webkit-align-items:flex-start;-moz-align-items:flex-start;align-items:flex-start;-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex}
-@media (min-width:480px){.project-age{-webkit-align-items:center;-moz-align-items:center;align-items:center;width:45%}
+.projects-bar h1{margin-bottom:0!important;margin-top:0!important}
+.projects-bar .projects-add{display:flex;justify-content:flex-end;margin:-27px 0 20px}
+.projects-bar .projects-options{display:flex;flex-direction:column}
+@media (min-width:650px){.projects-bar .projects-add{margin-left:40px;margin-top:0;order:2}
+.projects-bar .projects-options{flex-direction:row}
 }
-.project-age .h1{margin:0;text-align:center}
-.project-age .h2{margin-bottom:0;margin-top:10px}
-.project-age .h3{text-align:left;font-size:14px;margin-top:8px;margin-bottom:0}
-.project-background h1{display:inline-block;margin-bottom:0;margin-top:0}
-.project-bar .form-control{-webkit-flex:1;-moz-flex:1;-ms-flex:1;flex:1;padding-left:8px}
-@media (min-width:768px){.project-bar .form-control{-webkit-flex:0;-moz-flex:0;-ms-flex:0;flex:0;min-width:200px}
-}
-.project-bar .project-sort .form-group{margin:0}
-.project-bar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:25px;margin:0 7px;vertical-align:middle;width:1px}
-.projects-content{padding-left:0;padding-right:0}
-.project-description.list-group-item-text{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;margin-bottom:0px;width:100%}
-@media (min-width:480px){.project-description.list-group-item-text{margin-bottom:0;width:55%}
-}
-.project-info.list-group-item{border-bottom:0;padding:10px 20px}
-.project-names.list-view-pf-description{-webkit-flex:1 1 auto;-moz-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;width:100%}
-@media (min-width:992px){.project-names.list-view-pf-description{width:50%}
-}
-.project-summary .h1{margin-top:0}
+.projects-bar .projects-search{display:flex;margin-bottom:20px}
+.projects-bar .projects-search .search-pf{display:block;flex:0 1 auto}
+.projects-bar .projects-search .search-pf.has-button .form-group{display:block}
+.projects-bar .projects-sort{flex:1 0 auto}
+.projects-bar .projects-sort .form-group{margin:0}
+.projects-bar .vertical-divider{border-left:1px solid #bbb;display:inline-block;height:27px;margin:0 7px;vertical-align:middle;width:1px}
+.projects-header{margin-top:21px}
+.projects-instructions-link{white-space:pre}
 .projects-list{border-top:0;margin-bottom:20px}
-.projects-list .project-info:hover{background-color:#bee1f4}
+.projects-list .project-info:hover{background-color:#def3ff}
 .terminal-font,kubernetes-container-terminal .terminal{font-family:"Monospace Regular","DejaVu Sans Mono",Menlo,Monaco,Consolas,monospace;line-height:1em;font-size:12px}
 @media (min-width:768px){.container-terminal-wrapper{background-color:#000}
 }

--- a/dist/styles/vendor.css
+++ b/dist/styles/vendor.css
@@ -128,7 +128,7 @@ ul.messenger-theme-flat .messenger-spinner{display:block;position:absolute;left:
 .selectize-control.plugin-drag_drop.multi>.selectize-input>div.ui-sortable-placeholder{visibility:visible!important;background:#f2f2f2!important;background:rgba(0,0,0,.06)!important;border:0!important;box-shadow:inset 0 0 12px 4px #fff}
 .selectize-control.plugin-drag_drop .ui-sortable-placeholder::after{content:'!';visibility:hidden}
 .selectize-control.plugin-drag_drop .ui-sortable-helper{box-shadow:0 2px 5px rgba(0,0,0,.2)}
-.selectize-dropdown-header{position:relative;padding:7px;border-bottom:1px solid #b7b7b7;background:#f4f4f4;border-radius:1px 1px 0 0}
+.selectize-dropdown-header{position:relative;padding:7px;border-bottom:1px solid #bbb;background:#f5f5f5;border-radius:1px 1px 0 0}
 .selectize-dropdown-header-close{position:absolute;right:7px;top:50%;color:#303030;opacity:.4;margin-top:-12px;line-height:20px;font-size:20px!important}
 .selectize-dropdown-header-close:hover{color:#000}
 .selectize-dropdown.plugin-optgroup_columns .optgroup{border-right:1px solid #f2f2f2;border-top:0 none;float:left;box-sizing:border-box}
@@ -136,33 +136,33 @@ ul.messenger-theme-flat .messenger-spinner{display:block;position:absolute;left:
 .selectize-dropdown.plugin-optgroup_columns .optgroup:before{display:none}
 .selectize-dropdown.plugin-optgroup_columns .optgroup-header{border-top:0 none}
 .selectize-control.plugin-remove_button [data-value]{position:relative;padding-right:24px!important}
-.selectize-control.plugin-remove_button [data-value] .remove{z-index:1;position:absolute;top:0;right:0;bottom:0;width:17px;text-align:center;font-weight:700;font-size:12px;color:inherit;text-decoration:none;vertical-align:middle;display:inline-block;border-radius:0 2px 2px 0;box-sizing:border-box}
-.selectize-control,.selectize-input{position:relative}
+.selectize-control.plugin-remove_button [data-value] .remove{z-index:1;position:absolute;top:0;right:0;bottom:0;width:17px;text-align:center;font-weight:700;font-size:12px;color:inherit;text-decoration:none;vertical-align:middle;display:inline-block;padding:2px 0 0;border-left:1px solid #bbb;border-radius:0 2px 2px 0;box-sizing:border-box}
 .selectize-control.plugin-remove_button [data-value] .remove:hover{background:rgba(0,0,0,.05)}
 .selectize-control.plugin-remove_button [data-value].active .remove{border-left-color:#00578d}
 .selectize-control.plugin-remove_button .disabled [data-value] .remove:hover{background:0 0}
 .selectize-control.plugin-remove_button .disabled [data-value] .remove{border-left-color:#fff}
+.selectize-control.plugin-remove_button .remove-single{position:absolute;right:28px;top:6px;font-size:23px}
+.selectize-control,.selectize-input{position:relative}
 .selectize-dropdown,.selectize-input,.selectize-input input{color:#303030;font-family:inherit;font-size:13px;line-height:18px;-webkit-font-smoothing:inherit}
 .selectize-control.single .selectize-input.input-active,.selectize-input{background:#fff;cursor:text;display:inline-block}
-.selectize-input{border:1px solid #b7b7b7;padding:7px 10px;display:inline-block;width:100%;overflow:hidden;z-index:1;box-sizing:border-box;box-shadow:inset 0 1px 1px rgba(0,0,0,.1);border-radius:1px}
+.selectize-input{border:1px solid #bbb;padding:7px 10px;display:inline-block;width:100%;overflow:hidden;z-index:1;box-sizing:border-box;box-shadow:inset 0 1px 1px rgba(0,0,0,.1);border-radius:1px}
 .selectize-control.multi .selectize-input.has-items{padding:5px 10px 2px}
 .selectize-input.full{background-color:#fff}
 .selectize-input.disabled,.selectize-input.disabled *{cursor:default!important}
 .selectize-input.focus{box-shadow:inset 0 1px 2px rgba(0,0,0,.15)}
 .selectize-input.dropdown-active{border-radius:1px 1px 0 0}
 .selectize-input>*{vertical-align:baseline;display:-moz-inline-stack;display:inline-block;zoom:1}
-.selectize-control.multi .selectize-input>div{cursor:pointer;margin:0 3px 3px 0;padding:2px 6px;background:#006e9c;color:#fff;border:0 solid #b7b7b7}
+.selectize-control.multi .selectize-input>div{cursor:pointer;margin:0 3px 3px 0;padding:2px 6px;background:#006e9c;color:#fff;border:0 solid #bbb}
 .selectize-control.multi .selectize-input>div.active{background:#92c836;color:#fff;border:0 solid #00578d}
 .selectize-control.multi .selectize-input.disabled>div,.selectize-control.multi .selectize-input.disabled>div.active{color:#fff;background:#9b9b9b;border:0 solid #fff}
 .selectize-input>input{display:inline-block!important;padding:0!important;min-height:0!important;max-height:none!important;max-width:100%!important;margin:0 1px!important;text-indent:0!important;border:0!important;background:0 0!important;line-height:inherit!important;-webkit-user-select:auto!important;box-shadow:none!important}
 .selectize-input>input::-ms-clear{display:none}
 .selectize-input>input:focus{outline:0!important}
 .selectize-input::after{content:' ';display:block;clear:left}
-.filter .navbar-filter-widget:after,ul.registry-image-layers li{clear:both}
 .selectize-input.dropdown-active::before{content:' ';display:block;position:absolute;background:0 0;height:1px;bottom:0;left:0;right:0}
-.selectize-dropdown{position:absolute;background:#fff;box-sizing:border-box;box-shadow:0 1px 3px rgba(0,0,0,.1);border-radius:0 0 1px 1px}
+.selectize-dropdown{position:absolute;background:#fff;box-sizing:border-box;border-radius:0 0 1px 1px}
 .selectize-dropdown [data-selectable]{cursor:pointer;overflow:hidden}
-.selectize-dropdown [data-selectable] .highlight{background:rgba(125,168,208,.2);border-radius:1px}
+.selectize-dropdown [data-selectable] .highlight{border-radius:1px}
 .selectize-dropdown .optgroup:first-child .optgroup-header{border-top:0 none}
 .selectize-dropdown .optgroup-header{color:#303030;background:#fff;cursor:default;padding-top:9px;font-weight:700;font-size:.85em}
 .selectize-dropdown .active{background-color:#f5fafd;color:#495c68}
@@ -180,51 +180,45 @@ ul.messenger-theme-flat .messenger-spinner{display:block;position:absolute;left:
 .selectize-control.multi .selectize-input.disabled [data-value]{color:#999;text-shadow:none;background:0 0;box-shadow:none}
 .selectize-control.multi .selectize-input.disabled [data-value],.selectize-control.multi .selectize-input.disabled [data-value] .remove{border-color:#e6e6e6}
 .selectize-control.multi .selectize-input.disabled [data-value] .remove{background:0 0}
-.selectize-control.multi .selectize-input [data-value]{box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 1px rgba(255,255,255,.03)}
 .selectize-control.multi .selectize-input [data-value].active{background-color:#0085d4;background-image:linear-gradient(to bottom,#008fd8,#0075cf);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff008fd8', endColorstr='#ff0075cf', GradientType=0)}
-.selectize-control.single .selectize-input{box-shadow:0 1px 0 rgba(0,0,0,.05),inset 0 1px 0 rgba(255,255,255,.8);background-color:#f9f9f9;background-color:rgba(0,0,0,0);background-image:linear-gradient(to bottom,transparent,transparent);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#00000000', GradientType=0)}
+.selectize-control.single .selectize-input{box-shadow:0 1px 0 rgba(0,0,0,.05),inset 0 1px 0 rgba(255,255,255,.8);background-color:#f9f9f9;background-image:linear-gradient(to bottom,#fefefe,#f2f2f2);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffefefe', endColorstr='#fff2f2f2', GradientType=0)}
 .selectize-dropdown .optgroup{border-top:1px solid transparent}
 .selectize-dropdown .optgroup:first-child{border-top:0 none}
-.selectize-control.plugin-remove_button [data-value]{font-size:12px}
-.selectize-control.plugin-remove_button [data-value] .remove{border-left:1px solid #005c83;padding:0}
-.selectize-control.multi .selectize-input [data-value]{padding:0 6px;margin:0 3px 0 0;text-shadow:0 1px 0 rgba(0,0,0,.2);border-radius:2px;background-color:#006e9c;background-image:linear-gradient(to bottom,#006e9c,#006e9c);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff006e9c', endColorstr='#ff006e9c', GradientType=0)}
-.selectize-control.multi .selectize-input [data-value]+[data-value]{margin-top:3px}
-.selectize-control.single .selectize-input,.selectize-dropdown.single{border-color:#b7b7b7}
+.selectize-control.multi .selectize-input [data-value]{box-shadow:none;line-height:18px;margin:2px 4px 2px 0;padding:0 6px;text-shadow:0 1px 0 rgba(0,0,0,.2);border-radius:2px;background-color:#006e9c!important;background-image:linear-gradient(to bottom,#006e9c,#006e9c)!important;background-repeat:repeat-x!important;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff006e9c', endColorstr='#ff006e9c', GradientType=0)!important}
+.selectize-control.plugin-remove_button .selectize-input .remove{border-left:0;padding:1px 0 0}
+.selectize-control.single .selectize-input,.selectize-dropdown.single{border-color:#bbb}
 .selectize-dropdown .optgroup-header,.selectize-dropdown [data-selectable]{padding:5px 20px 5px 7px;word-break:break-all;word-break:break-word;overflow-wrap:break-word}
-.filter{display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;-webkit-flex-flow:row nowrap;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch;min-width:220px}
-.filter .navbar-filter-widget{display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;-webkit-flex-flow:row nowrap;-ms-flex-flow:row nowrap;flex-flow:row nowrap;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch;min-width:0}
-.filter .navbar-filter-widget:after,.filter .navbar-filter-widget:before{content:" ";display:table}
-.filter .navbar-filter-widget .label-filter{background:#fff;-webkit-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;min-width:0;min-height:27px;border:1px solid #b7b7b7;border-radius:1px}
-.filter .navbar-filter-widget .label-filter.filter-active{border-color:#66afe9;outline:0;box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6)}
-.filter .navbar-filter-widget .label-filter .selectize-control{display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex}
-.filter .navbar-filter-widget .label-filter .selectize-control .item{word-break:break-all;word-break:break-word;overflow-wrap:break-word;max-width:100%}
-.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input{background:0 0;vertical-align:middle;padding:2px 8px;border:0;box-shadow:none;font-size:12px;-webkit-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;min-width:160px;width:100%}
+.filter{display:table;width:100%}
+.filter .navbar-filter-widget{display:table-row}
+.filter .navbar-filter-widget .label-filter{background:#fff;border:1px solid #bbb;box-shadow:inset 0 1px 1px rgba(0,0,0,.075);border-radius:1px;display:table-cell;transition:"border-color ease-in-out .15s, box-shadow ease-in-out .15s";width:100%}
+.filter .navbar-filter-widget .label-filter.filter-active{border-color:#0088ce;outline:0;box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(0,136,206,.6)}
+.filter .navbar-filter-widget .label-filter:hover{border-color:#7dc3e8}
+.filter .navbar-filter-widget .label-filter .selectize-control{display:inline-block}
+.filter .navbar-filter-widget .label-filter .selectize-control .item{max-width:100%;word-break:break-all;word-break:break-word;overflow-wrap:break-word}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input{background:0 0;border:0;box-shadow:none;-ms-flex:0 1 auto;flex:0 1 auto;font-size:12px;line-height:22px;padding:0 6px;vertical-align:middle;width:100%}
 .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input.full{min-width:0}
 .filter .navbar-filter-widget .label-filter .selectize-control .selectize-input.full:after{border:0}
-.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input{font-size:12px;height:21px}
-.filter .navbar-filter-widget .label-filter-add.btn{border-left:0;border-radius:0;font-size:12px;opacity:1;height:27px;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center}
-.filter .navbar-filter-widget .label-filter-add.btn.disabled{opacity:.75}
-.selectize-dropdown{z-index:9999;font-size:12px;margin:0 0 0 -1px;width:100%!important;border:1px solid #b7b7b7}
-.active-filters{line-height:0;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column}
-.active-filters .label-filter-active-filters{display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;padding-bottom:3px}
-.active-filters .label-filter-active-filters .label{-webkit-align-items:center;-ms-flex-align:center;align-items:center;background:#006e9c;border-radius:2px;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;-webkit-flex:0 1 auto;-ms-flex:0 1 auto;flex:0 1 auto;font-size:12px;font-weight:400;line-height:13px;padding-bottom:.3em;padding-top:.3em;text-shadow:0 1px 0 rgba(0,0,0,.2);word-break:break-all;word-break:break-word;overflow-wrap:break-word;white-space:normal;margin:2px 3px 2px 0}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input{font-size:12px;height:22px;margin-left:0!important;margin-right:0!important}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input::-webkit-input-placeholder{font-style:italic;color:#999}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input::-moz-placeholder{font-style:italic;color:#999;opacity:1}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input:-ms-input-placeholder{font-style:italic;color:#999}
+.filter .navbar-filter-widget .label-filter .selectize-control .selectize-input input::placeholder{color:#999;font-style:italic}
+.filter .navbar-filter-widget .label-filter-add.btn{border-left:0;border-radius:1px;display:table-cell}
+.selectize-dropdown{border:1px solid #bbb;box-shadow:0 6px 12px rgba(0,0,0,.175);font-size:12px;margin:1px 0 0 -1px;min-width:40%;padding:5px 0;z-index:9999}
+@media (min-width:768px){.selectize-dropdown{min-width:0;width:auto!important;white-space:nowrap}
+}
+.selectize-dropdown [data-selectable]{border-bottom:1px solid transparent;border-top:1px solid transparent;line-height:1.66666667;padding:1px 10px}
+.selectize-dropdown [data-selectable].active{background:#def3ff;border-color:#bee1f4;color:#4d5258}
+.selectize-dropdown [data-selectable] .highlight{background:0 0;font-weight:700}
+.active-filters{line-height:0;display:-ms-flexbox;display:flex;-ms-flex-direction:column;flex-direction:column}
+.active-filters .label-filter-active-filters{display:-ms-inline-flexbox;display:inline-flex;-ms-flex-wrap:wrap;flex-wrap:wrap}
+.active-filters .label-filter-active-filters .label{-ms-flex-align:center;align-items:center;background:#006e9c;border-radius:2px;display:-ms-inline-flexbox;display:inline-flex;-ms-flex:0 1 auto;flex:0 1 auto;font-size:12px;font-weight:400;line-height:13px;padding:.3em 6px;margin:3px 3px 0 0;text-shadow:0 1px 0 rgba(0,0,0,.2);word-break:break-all;word-break:break-word;overflow-wrap:break-word;white-space:normal}
 [overflow-hidden],[truncate]{overflow:hidden}
 .active-filters .label-filter-active-filters .label:hover{background:#006e9c}
-.active-filters .label-filter-active-filters .label i.fa-times{font-size:11px;padding-left:5px}
-.active-filters .label-filter-active-filters .label-filter-clear{display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;margin:2px 5px 2px 0;-webkit-align-items:center;-ms-flex-align:center;align-items:center}
-.active-filters .label-filter-active-filters .label-filter-clear .label-filtering-remove-all{margin:0}
+.active-filters .label-filter-active-filters .label i.fa-times{font-size:10px;padding-left:10px}
+.active-filters .label-filter-active-filters .label-filter-clear{display:-ms-inline-flexbox;display:inline-flex;margin:3px 3px 0 0;-ms-flex-align:center;align-items:center}
+.active-filters .label-filter-active-filters .label-filter-clear .label-filtering-remove-all{background:#39a5dc;margin:0}
 .active-filters .label-filter-active-filters .label-filter-clear .label-filtering-remove-all i.fa.fa-filter{padding-right:5px}
-@media (min-width:768px){.filter .active-filters{margin-top:0}
-.filter .selectize-control{display:inline-block}
-.selectize-dropdown{width:auto!important;white-space:nowrap}
-.label-filter-key .selectize-input.not-full{width:auto}
-}
-.navbar-filter-widget-collapse .form-group{margin-bottom:0;-webkit-flex:1 1 0%;-ms-flex:1 1 0%;flex:1 1 0%;min-width:0}
-.filter .navbar-filter-widget .label-filter-add.btn{margin-right:0;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;-webkit-align-items:stretch;-ms-flex-align:stretch;align-items:stretch}
-@media (max-width:767px){.selectize-dropdown{left:0!important;margin:0}
-.filter .navbar-filter-widget .label-filter{min-width:initial;width:84%}
-.filter .navbar-filter-widget .selectize-input{width:auto!important}
-}
 kubernetes-topology-graph{display:block;user-select:none}
 .kube-topology g{font-family:PatternFlyIcons-webfont;font-size:18px;text-anchor:middle;cursor:pointer}
 .kube-topology g text{stroke:none;stroke-width:0px}
@@ -259,6 +253,7 @@ dl.registry-image-tags .registry-image-tag:after{content:' ';white-space:pre}
 .registry-image-pull .fa-info-circle{font-size:15px;color:#888;padding:0px 5px}
 registry-image-layers{border:1px solid #d1d1d1;display:block;overflow-y:auto;max-height:200px}
 ul.registry-image-layers{list-style:none;background-image:-webkit-linear-gradient(top,#fff 12px,#d3d3d3 15px);background-image:-moz-linear-gradient(top,#fff 12px,#d3d3d3 15px);background-image:-o-linear-gradient(top,#fff 12px,#d3d3d3 15px);background-image:linear-gradient(top,#fff 12px,#d3d3d3 15px);background-size:2px 100%;background-repeat:no-repeat;margin:8px 10px 15px 15px;padding-left:0px;font-size:13px}
+ul.registry-image-layers li{clear:both}
 ul.registry-image-layers li:before{content:"\F111";font-family:FontAwesome;font-size:19px;line-height:19px;float:left;display:block;color:#09f;position:relative;left:-7px;top:1px;padding-bottom:9px}
 ul.registry-image-layers li.hint-add:before{color:#555753}
 ul.registry-image-layers li.hint-run:before{color:#4e9a06}


### PR DESCRIPTION
@jwforres asked me to see if we could simplify the design a bit now
that many of the planned enhancements from @ajacobs21e’s design were cut from
the implementation.  I initially set out to just mock the page so I
could make a screenshot, but ended up refactoring in order to figure
out options for a more condensed header.  @MarkDeMaria, I’d like to
walk you through the changes when you’re available.

@ajacobs21e, are you good with these design tweaks?

More than 5 projects:
![1400px-5](https://cloud.githubusercontent.com/assets/895728/19043258/677b5e72-895d-11e6-8868-ed6c9a968625.png)
![1199 png-5](https://cloud.githubusercontent.com/assets/895728/19043255/67794bf0-895d-11e6-87b0-cc74a78167b4.png)
![991px-5](https://cloud.githubusercontent.com/assets/895728/19043257/677a12ba-895d-11e6-9bc3-f01f825cb84f.png)
![649px-5](https://cloud.githubusercontent.com/assets/895728/19043256/6779fe56-895d-11e6-9a34-6b5795259676.png)
![32pxpn-5](https://cloud.githubusercontent.com/assets/895728/19043259/67861d8a-895d-11e6-85e6-e1312aa061ae.png)

cc: @jwforres
